### PR TITLE
Add executable-repo and library-repo target framework patterns

### DIFF
--- a/Directory.Build.props.executable-repo
+++ b/Directory.Build.props.executable-repo
@@ -28,8 +28,8 @@
     <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
-  <!-- Library projects: Have dots, not Source Generators -->
-  <PropertyGroup Condition="$(MSBuildProjectName.Contains('.')) AND !$(MSBuildProjectName.Contains('SourceGenerator'))">
+  <!-- Library projects: Have dots, not Tests/Benchmarks/Source Generators -->
+  <PropertyGroup Condition="$(MSBuildProjectName.Contains('.')) AND !$(MSBuildProjectName.EndsWith('Tests')) AND !$(MSBuildProjectName.Contains('Benchmark')) AND !$(MSBuildProjectName.Contains('SourceGenerator'))">
     <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
   </PropertyGroup>
 

--- a/Directory.Build.props.shared
+++ b/Directory.Build.props.shared
@@ -1,9 +1,23 @@
 <Project>
   <!--
     Shared .NET Build Properties for jas88 projects
-    Import this in your repo's Directory.Build.props:
 
-    <Import Project="build-standards/Directory.Build.props.shared" />
+    Choose the appropriate target framework pattern and import it in your repo's Directory.Build.props:
+
+    For repos with executables (apps, CLIs, services):
+      <Import Project="build-standards/Directory.Build.props.executable-repo" />
+
+    For repos with only libraries:
+      <Import Project="build-standards/Directory.Build.props.library-repo" />
+
+    Then import shared properties:
+      <Import Project="build-standards/Directory.Build.props.shared" />
+
+    The executable-repo pattern follows naming conventions:
+    - Projects WITHOUT dots are executables → single-target (latest .NET)
+    - Projects WITH dots are libraries → multi-target (all non-EOL .NET versions)
+
+    The library-repo pattern treats all projects (except tests/benchmarks) as libraries.
   -->
 
   <!-- Language and Analysis -->


### PR DESCRIPTION
## Summary

- Add `Directory.Build.props.executable-repo` for repos with executables (apps, CLIs)
- Add `Directory.Build.props.library-repo` for library-only repos
- Update docs in shared to explain the two patterns

## Bug Fix

The executable-repo pattern correctly excludes Tests and Benchmarks from the library condition, preventing a conflict where both `TargetFrameworks` (multi-target) and `TargetFramework` (single-target) would be set for test projects like `Foo.Tests`.

Without this fix, test projects would incorrectly multi-target because:
1. Library condition matches (contains `.`)
2. Tests condition also matches (ends with `Tests`)
3. Both set target framework properties, but `TargetFrameworks` takes precedence

## Usage

```xml
<Project>
  <Import Project="build-standards/Directory.Build.props.executable-repo" />
  <Import Project="build-standards/Directory.Build.props.shared" />
  <!-- repo-specific properties -->
</Project>
```

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR introduces two new MSBuild configuration patterns for .NET repositories: `executable-repo` for projects containing executables (apps, CLIs) and `library-repo` for library-only projects. The executable-repo pattern uses naming conventions (projects without dots are executables, projects with dots are libraries) to automatically configure single-target vs multi-target framework settings. Both patterns ensure tests, benchmarks, and source generators are single-target. The PR also fixes a bug where test projects could incorrectly be configured with conflicting `TargetFrameworks` and `TargetFramework` properties, and updates the shared documentation to guide users on which pattern to import.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Directory.Build.props.library-repo` |
| 2 | `Directory.Build.props.executable-repo` |
| 3 | `Directory.Build.props.shared` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduce executable-repo and library-repo target framework patterns to auto-configure single vs multi-targeting across repos. Fixes incorrect multi-targeting in test projects and updates shared docs.

- **New Features**
  - executable-repo: projects without dots are executables → single-target net10.0; with dots are libraries → multi-target net8.0;net9.0;net10.0. Tests, benchmarks, and source generators are single-target.
  - library-repo: libraries default to multi-target net8.0;net9.0;net10.0. Tests, benchmarks, and source generators are single-target net10.0.

- **Bug Fixes**
  - Excludes Tests and Benchmarks from the library condition to prevent TargetFrameworks and TargetFramework being set together on test projects.

<sup>Written for commit e2147cfec5267407ea2382849819520a3785bb12. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

