### PR TITLE
Move AOT properties to targets file for correct TFM evaluation

### DIFF
--- a/Directory.Build.props.shared
+++ b/Directory.Build.props.shared
@@ -33,17 +33,8 @@
     <RunAnalyzersDuringBuild>true</RunAnalyzersDuringBuild>
   </PropertyGroup>
 
-  <!-- AOT and Trimming Compatibility (only for frameworks that support it) -->
-  <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">
-    <IsAotCompatible>true</IsAotCompatible>
-    <IsTrimmable>true</IsTrimmable>
-  </PropertyGroup>
-
-  <!-- Explicitly disable AOT for netstandard to suppress NETSDK1210 warnings -->
-  <PropertyGroup Condition="$(TargetFramework.StartsWith('netstandard'))">
-    <IsAotCompatible>false</IsAotCompatible>
-    <EnableAotAnalyzer>false</EnableAotAnalyzer>
-  </PropertyGroup>
+  <!-- NOTE: AOT properties moved to Directory.Build.targets.shared -->
+  <!-- Must be evaluated after TargetFramework is set by the project file -->
 
   <!-- Deterministic Builds -->
   <PropertyGroup>

--- a/Directory.Build.targets.shared
+++ b/Directory.Build.targets.shared
@@ -1,0 +1,18 @@
+<Project>
+  <!--
+    Shared .NET Build Targets for jas88 projects
+    Import this in your repo's Directory.Build.targets:
+
+    <Import Project="build-standards/Directory.Build.targets.shared" />
+
+    These properties must be in a targets file (not props) because they
+    depend on $(TargetFramework) which is not set until after props files.
+  -->
+
+  <!-- AOT and Trimming Compatibility (only for frameworks that support it) -->
+  <!-- Condition ensures property isn't set for netstandard/older frameworks -->
+  <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">
+    <IsAotCompatible>true</IsAotCompatible>
+    <IsTrimmable>true</IsTrimmable>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
## Summary
- Move IsAotCompatible/IsTrimmable properties from props to targets file
- Fixes NETSDK1210 warnings on netstandard2.0 projects (e.g., source generators)

## Root Cause
Props files are imported BEFORE the project file sets `TargetFramework`. When the condition `$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))` is evaluated in props, `$(TargetFramework)` is empty/undefined.

Targets files are imported AFTER the project file, so `$(TargetFramework)` is correctly set when the condition is evaluated.

## Changes
- Remove AOT PropertyGroup from `Directory.Build.props.shared`
- Add new `Directory.Build.targets.shared` with AOT properties
- Consumers need to import the targets file in their `Directory.Build.targets`

## Test Plan
- Build SynthEHR.SourceGenerators (netstandard2.0) - no NETSDK1210 warning
- Build SynthEHR.Core (net8.0/net9.0/net10.0) - AOT properties still enabled

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes NETSDK1210 warnings in netstandard2.0 projects by moving AOT-related properties (`IsAotCompatible` and `IsTrimmable`) from the props file to a new targets file. The issue occurred because props files are evaluated before the project file sets `TargetFramework`, causing the MSBuild condition to evaluate against an empty value. By moving these properties to a targets file that imports after the project file, the `TargetFramework` variable is correctly set when the condition is evaluated, ensuring AOT properties only apply to net7.0+ projects.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Directory.Build.targets.shared` |
| 2 | `Directory.Build.props.shared` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved IsAotCompatible and IsTrimmable from props to targets so TargetFramework is set when evaluated. Fixes NETSDK1210 warnings on netstandard2.0 while keeping AOT/trimming enabled on net7.0+.

- **Migration**
  - Import the shared targets file in your Directory.Build.targets: <Import Project="build-standards/Directory.Build.targets.shared" />

<sup>Written for commit ea9fb4d4e8038586d981905ba940d220aaf55084. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

