### PR TITLE
Add Microsoft Testing Platform (MTP) support

### DIFF
--- a/Directory.Build.props.shared
+++ b/Directory.Build.props.shared
@@ -78,7 +78,8 @@
   </ItemGroup>
 
   <!-- Microsoft Testing Platform (MTP) for test projects -->
-  <PropertyGroup Condition="$(MSBuildProjectDirectory.Contains('Test'))">
+  <!-- Uses IsTestProject property which is set by Microsoft.NET.Test.Sdk or explicitly in .csproj -->
+  <PropertyGroup Condition="'$(IsTestProject)' == 'true'">
     <!-- Enable NUnit runner (MTP instead of VSTest) -->
     <EnableNUnitRunner>true</EnableNUnitRunner>
     <!-- Required for MTP - test projects must be executables -->
@@ -86,7 +87,7 @@
   </PropertyGroup>
 
   <!-- Code coverage for test projects (Microsoft Testing Platform compatible) -->
-  <ItemGroup Condition="$(MSBuildProjectDirectory.Contains('Test'))">
+  <ItemGroup Condition="'$(IsTestProject)' == 'true'">
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" PrivateAssets="All" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- Enable NUnitRunner for MTP instead of VSTest
- Set OutputType=Exe for test projects (required by MTP)
- Add Microsoft.Testing.Extensions.CodeCoverage for MTP coverage
- Keep coverlet.collector as fallback

## Context
MTP is the modern replacement for VSTest, released stable in early 2024. Benefits include embedded runner, better diagnostics, and simpler configuration.

## Test Plan
- Apply in FAnsiSql repo to verify test execution
- Ensure code coverage still works

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches test execution to Microsoft Testing Platform (MTP) with the NUnit runner to modernize and simplify our tests. Keeps VSTest compatibility via Coverlet.

- **New Features**
  - Enable NUnit runner (MTP) for IsTestProject-tagged test projects.
  - Set OutputType=Exe for test projects (required by MTP).
  - Add Microsoft.Testing.Extensions.CodeCoverage; keep coverlet.collector as fallback.

<sup>Written for commit 696602079c50bdae9c509f083eb8fe00d0612535. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR migrates test projects from VSTest to Microsoft Testing Platform (MTP) by enabling the `EnableNUnitRunner` property, changing test project output type to `Exe` (required by MTP), and adding `Microsoft.Testing.Extensions.CodeCoverage` for code coverage support while keeping `coverlet.collector` as a fallback for VSTest compatibility.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Directory.Build.props.shared` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->