### PR TITLE
Update CodeCoverage to 18.3.2

### DIFF
--- a/Directory.Packages.props.shared
+++ b/Directory.Packages.props.shared
@@ -8,6 +8,6 @@
     <!-- Build infrastructure packages added by Directory.Build.props.shared -->
     <PackageVersion Include="MinVer" Version="6.0.0" />
     <PackageVersion Include="DotNet.ReproducibleBuilds" Version="1.2.25" />
-    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.3.1" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.3.2" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- Update Microsoft.Testing.Extensions.CodeCoverage from 18.3.1 to 18.3.2

This version bump is needed because 18.3.1 has a crash during code coverage collection on .NET 10 with async code. See https://github.com/microsoft/codecoverage/issues/203 for details.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR updates the `Microsoft.Testing.Extensions.CodeCoverage` package from version 18.3.1 to 18.3.2 to fix a crash that occurs during code coverage collection on .NET 10 with async code.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Directory.Packages.props.shared` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade code coverage tooling to fix a crash on .NET 10 when collecting coverage for async code. Stabilizes test runs and coverage reports (see microsoft/codecoverage#203).

- **Dependencies**
  - Microsoft.Testing.Extensions.CodeCoverage: 18.3.1 to 18.3.2

<sup>Written for commit 6145f43748b641f5e695419d18934653789ae09e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

