### PR TITLE
Add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-      day: "monday"
+      day: "saturday"
     open-pull-requests-limit: 5
     commit-message:
       prefix: "build"
@@ -18,7 +18,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-      day: "monday"
+      day: "saturday"
     open-pull-requests-limit: 5
     commit-message:
       prefix: "ci"


### PR DESCRIPTION
Keep Nuget and Github action dependencies current, checking each Saturday.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Dependabot to auto-update NuGet packages and GitHub Actions every Saturday. Keeps dependencies current and reduces manual work.

- **Dependencies**
  - Monitors NuGet and GitHub Actions in the repo root.
  - Weekly schedule on Saturday; max 5 open PRs.
  - Commit prefixes: "build" (NuGet) and "ci" (Actions).

<sup>Written for commit 370178abfb300b584cfe590d04871ea82898dcad. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

