### PR TITLE
Update Renovate GitHub Action to version 46.0.0

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: renovatebot/github-action@v42
+      - uses: renovatebot/github-action@v46.0.0
         with:
           # Use the built-in GITHUB_TOKEN for authentication.
           # This workflow has Contents and Pull Requests write permissions


### PR DESCRIPTION
Fix renovate action tag

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR updates the Renovate GitHub Action from version 42 to version 46.0.0 in the workflow configuration, using a more specific version tag format.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `.github/workflows/renovate.yml` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the Renovate GitHub Action from v42 to v46.0.0 to use the latest major release. This is a dependency bump only; workflow logic remains unchanged.

<sup>Written for commit 81e3d6a05538d1b1520fc361eccf0eaf2213cb3e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

