### PR TITLE
Fix Renovate workflow to specify target repository

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -21,3 +21,6 @@ jobs:
           # This workflow has Contents and Pull Requests write permissions
           # which are sufficient for Renovate to create and update PRs.
           token: ${{ secrets.GITHUB_TOKEN }}
+          configurationFile: renovate.json
+        env:
+          RENOVATE_REPOSITORIES: ${{ github.repository }}


### PR DESCRIPTION
## Summary
- Renovate was logging `No repositories found` because the workflow didn't tell it which repository to scan
- Add `RENOVATE_REPOSITORIES` env var set to `${{ github.repository }}` so Renovate knows to scan this repo
- Add explicit `configurationFile` pointing to `renovate.json`

## Test plan
- [ ] Trigger the Renovate workflow manually and verify it no longer logs "No repositories found"
- [ ] Verify Renovate discovers `Directory.Packages.props.shared` and checks for NuGet updates

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes the Renovate workflow configuration by adding the `RENOVATE_REPOSITORIES` environment variable to specify the target repository and explicitly setting the `configurationFile` parameter. This resolves the issue where Renovate was logging "No repositories found" because it didn't know which repository to scan.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `.github/workflows/renovate.yml` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Renovate workflow so it scans this repository and uses renovate.json, resolving the “No repositories found” log and enabling dependency PRs.

- **Bug Fixes**
  - Set RENOVATE_REPOSITORIES to ${{ github.repository }}.
  - Specify configurationFile: renovate.json.

<sup>Written for commit 4b7fbb7d02658bd2721a33f8a3dee1108bc6a33b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

