### PR TITLE
build: Update dependency MinVer to 6.1.0

### DIFF
--- a/Directory.Packages.props.shared
+++ b/Directory.Packages.props.shared
@@ -6,7 +6,7 @@
   -->
   <ItemGroup>
     <!-- Build infrastructure packages added by Directory.Build.props.shared -->
-    <PackageVersion Include="MinVer" Version="6.0.0" />
+    <PackageVersion Include="MinVer" Version="6.1.0" />
     <PackageVersion Include="DotNet.ReproducibleBuilds" Version="1.2.25" />
     <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.3.2" />
   </ItemGroup>


### PR DESCRIPTION

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR updates the MinVer build infrastructure package from version 6.0.0 to 6.1.0 in the centrally managed package versions file.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Directory.Packages.props.shared` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update MinVer from 6.0.0 to 6.1.0 to keep our versioning tooling current. No functional changes; only the centralized package version in Directory.Packages.props.shared is bumped.

<sup>Written for commit 99da3b0045f7b10e6868baf89c54b4cc95f15ad7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

